### PR TITLE
added new keybinding to vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -62,3 +62,5 @@ filetype plugin indent on    " required
 " Plugin specific keybindings
 map <C-n> :NERDTreeToggle<CR>
 
+" Keybindings
+nnoremap <C-i> i_<Esc>r


### PR DESCRIPTION
This PR makes the following changes:
* maps ctrl-i to insert a single character and return to normal mode